### PR TITLE
fix: remove redundant error logging in exception handling

### DIFF
--- a/dashscope/api_entities/http_request.py
+++ b/dashscope/api_entities/http_request.py
@@ -372,5 +372,4 @@ class HttpRequest(AioBaseRequest):
                 for rsp in self._handle_response(response):
                     yield rsp
         except BaseException as e:
-            logger.error(e)
             raise e


### PR DESCRIPTION
The current code logs exceptions with `logger.error(e)` before rethrowing them via `raise e`, which has issues:

1. The SDK's internal error logs, as intermediate-layer records, may duplicate users' upper-level logs, causing redundancy. Such 
logging should be handled by users themselves.
2. `logger.error(e)` may print empty logs.
<img width="2317" height="120" alt="image" src="https://github.com/user-attachments/assets/df29c42c-ffe9-45b3-95c3-5204feb6e327" />

It is recommended to remove these logs or lower their level to debug.