### PR TITLE
fix: __getattr__ raises AttributeError instead of KeyError

### DIFF
--- a/dashscope/api_entities/dashscope_response.py
+++ b/dashscope/api_entities/dashscope_response.py
@@ -59,7 +59,10 @@ class DictMixin(dict):
         return super().__setitem__(attr, value)
 
     def __getattr__(self, attr):
-        return self[attr]
+        try:
+            return self[attr]
+        except KeyError:
+            raise AttributeError(attr) from None
 
     def __setattr__(self, attr, value):
         self[attr] = value


### PR DESCRIPTION
## Summary
- `DashScopeAPIResponse.__getattr__` raised `KeyError` when an attribute was missing, breaking `getattr(obj, name, default)` and `hasattr(obj, name)` which rely on `AttributeError` for fallback behavior
- Wraps the dict lookup in a try/except to convert `KeyError` to `AttributeError`

Closes #114

## Test plan
- [x] `getattr(response.output, "reasoning_content", None)` returns `None` instead of raising `KeyError`
- [x] `hasattr(response.output, "reasoning_content")` returns `False` instead of raising `KeyError`
- [x] Existing attribute access still works normally

Happy to add unit tests for this if preferred.