### PR TITLE
fix: raise AttributeError instead of KeyError in __getattr__

### DIFF
--- a/dashscope/api_entities/dashscope_response.py
+++ b/dashscope/api_entities/dashscope_response.py
@@ -59,7 +59,10 @@ class DictMixin(dict):
         return super().__setitem__(attr, value)
 
     def __getattr__(self, attr):
-        return self[attr]
+        try:
+            return self[attr]
+        except KeyError:
+            raise AttributeError(attr) from None
 
     def __setattr__(self, attr, value):
         self[attr] = value


### PR DESCRIPTION
Fixed the bug described in issue #114. Here's what was wrong and how I fixed it:

## Problem
DashScopeAPIResponse.__getattr__ raised KeyError when an attribute was missing, but Python's attribute-access protocol requires AttributeError. This broke common Python patterns like getattr(obj, name, default) and hasattr(obj, name) — both rely on AttributeError to trigger the default/fallback path.

## Fix
Changed __getattr__ in dashscope/api_entities/dashscope_response.py to catch the KeyError and re-raise it as AttributeError:

```python
def __getattr__(self, attr):
    try:
        return self[attr]
    except KeyError:
        raise AttributeError(attr) from None
```

## Tested by
All 4 test cases pass:
- getattr(response, 'missing', 'default') → returns 'default' ✓
- hasattr(response, 'missing') → returns False ✓  
- response.existing_attr → still works correctly ✓
- response.missing_attr → raises AttributeError (correct) ✓

Fixes: #114