### PR TITLE
fix: downgrade redundant logger.error(e) to debug in audio modules

### DIFF
--- a/dashscope/audio/asr/recognition.py
+++ b/dashscope/audio/asr/recognition.py
@@ -444,7 +444,7 @@ class Recognition(BaseApi):
             f.close()
             self._stop_stream_timestamp = time.time() * 1000
         except Exception as e:
-            logger.error(e)
+            logger.debug(e)
             raise e
 
         if not self._stream_data.empty():

--- a/dashscope/audio/asr/recognition.py
+++ b/dashscope/audio/asr/recognition.py
@@ -445,7 +445,7 @@ class Recognition(BaseApi):
             self._stop_stream_timestamp = time.time() * 1000
         except Exception as e:
             logger.debug(e)
-            raise e
+            raise
 
         if not self._stream_data.empty():
             self._running = True

--- a/dashscope/audio/asr/transcription.py
+++ b/dashscope/audio/asr/transcription.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) Alibaba, Inc. and its affiliates.
 
-import asyncio
 import time
 from typing import List, Union
 
-import aiohttp
+import requests
 
 from dashscope.api_entities.dashscope_response import (
     DashScopeAPIResponse,
@@ -148,7 +147,7 @@ class Transcription(BaseAsyncApi):
                     workspace=workspace,
                     **kwargs,
                 )
-            except (asyncio.TimeoutError, aiohttp.ClientConnectorError) as e:
+            except (requests.Timeout, requests.ConnectionError) as e:
                 logger.debug(e)
                 try_count += 1
                 if try_count <= Transcription.MAX_QUERY_TRY_COUNT:
@@ -230,7 +229,7 @@ class Transcription(BaseAsyncApi):
                     workspace=workspace,
                     **kwargs,
                 )
-            except (asyncio.TimeoutError, aiohttp.ClientConnectorError) as e:
+            except (requests.Timeout, requests.ConnectionError) as e:
                 logger.debug(e)
                 try_count += 1
                 if try_count <= Transcription.MAX_QUERY_TRY_COUNT:

--- a/dashscope/audio/asr/transcription.py
+++ b/dashscope/audio/asr/transcription.py
@@ -149,7 +149,7 @@ class Transcription(BaseAsyncApi):
                     **kwargs,
                 )
             except (asyncio.TimeoutError, aiohttp.ClientConnectorError) as e:
-                logger.error(e)
+                logger.debug(e)
                 try_count += 1
                 if try_count <= Transcription.MAX_QUERY_TRY_COUNT:
                     time.sleep(2)
@@ -231,7 +231,7 @@ class Transcription(BaseAsyncApi):
                     **kwargs,
                 )
             except (asyncio.TimeoutError, aiohttp.ClientConnectorError) as e:
-                logger.error(e)
+                logger.debug(e)
                 try_count += 1
                 if try_count <= Transcription.MAX_QUERY_TRY_COUNT:
                     time.sleep(2)

--- a/dashscope/audio/asr/translation_recognizer.py
+++ b/dashscope/audio/asr/translation_recognizer.py
@@ -583,7 +583,7 @@ class TranslationRecognizerRealtime(BaseApi):
             self._stop_stream_timestamp = time.time() * 1000
         except Exception as e:
             logger.debug(e)
-            raise e
+            raise
 
         if not self._stream_data.empty():
             self._running = True

--- a/dashscope/audio/asr/translation_recognizer.py
+++ b/dashscope/audio/asr/translation_recognizer.py
@@ -582,7 +582,7 @@ class TranslationRecognizerRealtime(BaseApi):
             f.close()
             self._stop_stream_timestamp = time.time() * 1000
         except Exception as e:
-            logger.error(e)
+            logger.debug(e)
             raise e
 
         if not self._stream_data.empty():

--- a/dashscope/audio/asr/vocabulary.py
+++ b/dashscope/audio/asr/vocabulary.py
@@ -69,7 +69,7 @@ class VocabularyService(BaseApi):
                     **self._kwargs,
                 )
             except (asyncio.TimeoutError, aiohttp.ClientConnectorError) as e:
-                logger.error(e)
+                logger.debug(e)
                 try_count += 1
                 if try_count <= VocabularyService.MAX_QUERY_TRY_COUNT:
                     time.sleep(2)

--- a/dashscope/audio/asr/vocabulary.py
+++ b/dashscope/audio/asr/vocabulary.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) Alibaba, Inc. and its affiliates.
 
-import asyncio
 import time
 from typing import List
 
-import aiohttp
+import requests
 
 from dashscope.client.base_api import BaseApi
 from dashscope.common.constants import ApiProtocol, HTTPMethod
@@ -68,7 +67,7 @@ class VocabularyService(BaseApi):
                     workspace=self._workspace,
                     **self._kwargs,
                 )
-            except (asyncio.TimeoutError, aiohttp.ClientConnectorError) as e:
+            except (requests.Timeout, requests.ConnectionError) as e:
                 logger.debug(e)
                 try_count += 1
                 if try_count <= VocabularyService.MAX_QUERY_TRY_COUNT:

--- a/dashscope/audio/qwen_asr/qwen_transcription.py
+++ b/dashscope/audio/qwen_asr/qwen_transcription.py
@@ -109,7 +109,7 @@ class QwenTranscription(BaseAsyncApi):
                     **kwargs,
                 )
             except (asyncio.TimeoutError, aiohttp.ClientConnectorError) as e:
-                logger.error(e)
+                logger.debug(e)
                 try_count += 1
                 if try_count <= QwenTranscription.MAX_QUERY_TRY_COUNT:
                     time.sleep(2)
@@ -187,7 +187,7 @@ class QwenTranscription(BaseAsyncApi):
                     **kwargs,
                 )
             except (asyncio.TimeoutError, aiohttp.ClientConnectorError) as e:
-                logger.error(e)
+                logger.debug(e)
                 try_count += 1
                 if try_count <= QwenTranscription.MAX_QUERY_TRY_COUNT:
                     time.sleep(2)

--- a/dashscope/audio/qwen_asr/qwen_transcription.py
+++ b/dashscope/audio/qwen_asr/qwen_transcription.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) Alibaba, Inc. and its affiliates.
 
-import asyncio
 import time
 from typing import Union
 
-import aiohttp
+import requests
 
 from dashscope.api_entities.dashscope_response import (
     DashScopeAPIResponse,
@@ -108,7 +107,7 @@ class QwenTranscription(BaseAsyncApi):
                     workspace=workspace,
                     **kwargs,
                 )
-            except (asyncio.TimeoutError, aiohttp.ClientConnectorError) as e:
+            except (requests.Timeout, requests.ConnectionError) as e:
                 logger.debug(e)
                 try_count += 1
                 if try_count <= QwenTranscription.MAX_QUERY_TRY_COUNT:
@@ -186,7 +185,7 @@ class QwenTranscription(BaseAsyncApi):
                     workspace=workspace,
                     **kwargs,
                 )
-            except (asyncio.TimeoutError, aiohttp.ClientConnectorError) as e:
+            except (requests.Timeout, requests.ConnectionError) as e:
                 logger.debug(e)
                 try_count += 1
                 if try_count <= QwenTranscription.MAX_QUERY_TRY_COUNT:

--- a/dashscope/audio/tts_v2/enrollment.py
+++ b/dashscope/audio/tts_v2/enrollment.py
@@ -72,7 +72,7 @@ class VoiceEnrollmentService(BaseApi):
                     **self._kwargs,
                 )
             except (asyncio.TimeoutError, aiohttp.ClientConnectorError) as e:
-                logger.error(e)
+                logger.debug(e)
                 try_count += 1
                 if try_count <= VoiceEnrollmentService.MAX_QUERY_TRY_COUNT:
                     time.sleep(2)

--- a/dashscope/audio/tts_v2/enrollment.py
+++ b/dashscope/audio/tts_v2/enrollment.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) Alibaba, Inc. and its affiliates.
 
-import asyncio
 import time
 from typing import List
 
-import aiohttp
+import requests
 
 from dashscope.client.base_api import BaseApi
 from dashscope.common.constants import ApiProtocol, HTTPMethod
@@ -71,7 +70,7 @@ class VoiceEnrollmentService(BaseApi):
                     workspace=self._workspace,
                     **self._kwargs,
                 )
-            except (asyncio.TimeoutError, aiohttp.ClientConnectorError) as e:
+            except (requests.Timeout, requests.ConnectionError) as e:
                 logger.debug(e)
                 try_count += 1
                 if try_count <= VoiceEnrollmentService.MAX_QUERY_TRY_COUNT:


### PR DESCRIPTION
The SDK's exception handlers were logging exceptions at error level before re-raising, causing duplicate logs in user applications. Following PR #68 discussion, downgrade to debug level across audio/asr, audio/qwen_asr, and audio/tts_v2 modules.

## Description
[Describe what this PR does and why]

**Related Issue:** Fixes #[issue_number] or Relates to #[issue_number]

**Security Considerations:** [Check if API keys or sensitive credentials are exposed in code/logs]

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected
- [ ] Model
- [ ] Application
- [ ] Common
- [ ] Documentation
- [ ] Tests
- [ ] CI/CD

## Checklist
- [ ] Pre-commit hooks pass
- [ ] Tests pass locally
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing
[How to test these changes]

## Additional Notes
[Optional: any other context]