### PR TITLE
fix: retry once when a pooled keep-alive connection is dropped

### DIFF
--- a/dashscope/api_entities/aio_session.py
+++ b/dashscope/api_entities/aio_session.py
@@ -11,10 +11,12 @@ import atexit
 import ssl
 import threading
 import weakref
-from typing import Optional
+from typing import Awaitable, Callable, Optional
 
 import aiohttp
 import certifi
+
+from dashscope.common.logging import logger
 
 _shared_ssl_context: Optional[ssl.SSLContext] = None
 _aio_sessions: "weakref.WeakKeyDictionary" = weakref.WeakKeyDictionary()
@@ -104,3 +106,24 @@ async def close_shared_aio_session() -> None:
         session = _aio_sessions.pop(loop, None)
     if session is not None and not session.closed:
         await session.close()
+
+
+async def send_with_retry_async(
+    send: Callable[[], Awaitable[aiohttp.ClientResponse]],
+) -> aiohttp.ClientResponse:
+    """Send an async request, retrying once on a dropped pooled connection.
+
+    A keep-alive connection idle in the connector pool may have been
+    closed by the server or an intermediate LB; reusing it raises
+    ClientConnectionError before any response bytes arrive, so the
+    request was not processed and is safe to resend on a fresh
+    connection.
+    """
+    try:
+        return await send()
+    except aiohttp.ClientConnectionError as e:
+        logger.debug(
+            "Connection dropped before response, retrying once: %s",
+            e,
+        )
+        return await send()

--- a/dashscope/api_entities/aiohttp_request.py
+++ b/dashscope/api_entities/aiohttp_request.py
@@ -7,7 +7,10 @@ from typing import Optional
 
 import aiohttp
 
-from dashscope.api_entities.aio_session import get_shared_aio_session
+from dashscope.api_entities.aio_session import (
+    get_shared_aio_session,
+    send_with_retry_async,
+)
 from dashscope.api_entities.base_request import AioBaseRequest
 from dashscope.api_entities.dashscope_response import DashScopeAPIResponse
 from dashscope.common.constants import (
@@ -294,22 +297,26 @@ class AioHttpRequest(AioBaseRequest):
                     body = json.dumps(obj, ensure_ascii=False).encode(
                         "utf-8",
                     )
-                    response = await session.request(
-                        "POST",
-                        url=self.url,
-                        data=body,
-                        headers=self.headers,
-                        timeout=request_timeout,
+                    response = await send_with_retry_async(
+                        lambda: session.request(
+                            "POST",
+                            url=self.url,
+                            data=body,
+                            headers=self.headers,
+                            timeout=request_timeout,
+                        ),
                     )
             elif self.method == HTTPMethod.GET:
                 params = {}
                 if hasattr(self, "data") and self.data is not None:
                     params = getattr(self.data, "parameters", {})
-                response = await session.get(
-                    url=self.url,
-                    params=params,
-                    headers=self.headers,
-                    timeout=request_timeout,
+                response = await send_with_retry_async(
+                    lambda: session.get(
+                        url=self.url,
+                        params=params,
+                        headers=self.headers,
+                        timeout=request_timeout,
+                    ),
                 )
             else:
                 raise UnsupportedHTTPMethod(

--- a/dashscope/api_entities/http_request.py
+++ b/dashscope/api_entities/http_request.py
@@ -9,7 +9,10 @@ from typing import Callable, Optional, Dict, Union
 import aiohttp
 import requests
 
-from dashscope.api_entities.aio_session import get_shared_aio_session
+from dashscope.api_entities.aio_session import (
+    get_shared_aio_session,
+    send_with_retry_async,
+)
 from dashscope.api_entities.base_request import AioBaseRequest
 from dashscope.api_entities.dashscope_response import DashScopeAPIResponse
 from dashscope.common.constants import (
@@ -236,12 +239,14 @@ class HttpRequest(AioBaseRequest):
                         body = json.dumps(obj, ensure_ascii=False).encode(
                             "utf-8",
                         )
-                        response = await session.request(
-                            "POST",
-                            url=self.url,
-                            data=body,
-                            headers=self.headers,
-                            timeout=request_timeout,
+                        response = await send_with_retry_async(
+                            lambda: session.request(
+                                "POST",
+                                url=self.url,
+                                data=body,
+                                headers=self.headers,
+                                timeout=request_timeout,
+                            ),
                         )
                 elif self.method == HTTPMethod.GET:
                     params = {}
@@ -249,11 +254,13 @@ class HttpRequest(AioBaseRequest):
                         params = getattr(self.data, "parameters", {})
                     if params:
                         params = self.__handle_parameters(params)
-                    response = await session.get(
-                        url=self.url,
-                        params=params,
-                        headers=self.headers,
-                        timeout=request_timeout,
+                    response = await send_with_retry_async(
+                        lambda: session.get(
+                            url=self.url,
+                            params=params,
+                            headers=self.headers,
+                            timeout=request_timeout,
+                        ),
                     )
                 else:
                     raise UnsupportedHTTPMethod(

--- a/dashscope/api_entities/http_request.py
+++ b/dashscope/api_entities/http_request.py
@@ -4,7 +4,7 @@ import datetime
 import json
 import threading
 from http import HTTPStatus
-from typing import Optional, Dict, Union
+from typing import Callable, Optional, Dict, Union
 
 import aiohttp
 import requests
@@ -44,6 +44,26 @@ def _get_shared_sync_session() -> requests.Session:
             if _shared_sync_session is None:
                 _shared_sync_session = requests.Session()
     return _shared_sync_session
+
+
+def _send_with_retry(
+    send: Callable[[], requests.Response],
+) -> requests.Response:
+    """Send a request, retrying once on a dropped pooled connection.
+
+    A keep-alive connection idle in the pool may have been closed by the
+    server or an intermediate LB; reusing it raises ConnectionError before
+    any response bytes arrive, so the request was not processed and is
+    safe to resend on a fresh connection.
+    """
+    try:
+        return send()
+    except requests.exceptions.ConnectionError as e:
+        logger.debug(
+            "Connection dropped before response, retrying once: %s",
+            e,
+        )
+        return send()
 
 
 class HttpRequest(AioBaseRequest):
@@ -505,22 +525,26 @@ class HttpRequest(AioBaseRequest):
                     body = json.dumps(obj, ensure_ascii=False).encode(
                         "utf-8",
                     )
-                    response = session.post(
-                        url=self.url,
-                        stream=self.stream,
-                        data=body,
-                        headers={**self.headers},
-                        timeout=self.timeout,
+                    response = _send_with_retry(
+                        lambda: session.post(
+                            url=self.url,
+                            stream=self.stream,
+                            data=body,
+                            headers={**self.headers},
+                            timeout=self.timeout,
+                        ),
                     )
             elif self.method == HTTPMethod.GET:
                 params = {}
                 if hasattr(self, "data") and self.data is not None:
                     params = getattr(self.data, "parameters", {})
-                response = session.get(
-                    url=self.url,
-                    params=params,
-                    headers=self.headers,
-                    timeout=self.timeout,
+                response = _send_with_retry(
+                    lambda: session.get(
+                        url=self.url,
+                        params=params,
+                        headers=self.headers,
+                        timeout=self.timeout,
+                    ),
                 )
             else:
                 raise UnsupportedHTTPMethod(

--- a/dashscope/version.py
+++ b/dashscope/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) Alibaba, Inc. and its affiliates.
 
-__version__ = "1.26.6"
+__version__ = "1.26.7"

--- a/tests/unit/test_async_custom_session.py
+++ b/tests/unit/test_async_custom_session.py
@@ -669,3 +669,99 @@ class TestAsyncSessionLifecycle:
 
         # 验证 session 没有被关闭（因为是外部 session）
         mock_session.close.assert_not_called()
+
+
+class TestAsyncConnectionRetry:
+    """测试异步池化连接被远端关闭后的重试行为"""
+
+    def _build_post_request(self):
+        http_request = HttpRequest(
+            url="http://example.com/api",
+            api_key="fake-api-key",
+            http_method=HTTPMethod.POST,
+            stream=False,
+        )
+        http_request.data = ApiRequestData(
+            model="test-model",
+            task_group="test",
+            task="test",
+            function="test",
+            input_data={"test": "data"},
+            form=None,
+            is_binary_input=False,
+            api_protocol=ApiProtocol.HTTPS,
+        )
+        return http_request
+
+    @staticmethod
+    def _ok_response():
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=None)
+        return mock_response
+
+    @pytest.mark.asyncio
+    async def test_retry_once_on_connection_error(self):
+        """连接被远端关闭时重试一次并成功"""
+        mock_session = AsyncMock()
+        mock_response = self._ok_response()
+        mock_session.request.side_effect = [
+            aiohttp.ClientConnectionError("Server disconnected"),
+            mock_response,
+        ]
+
+        http_request = self._build_post_request()
+
+        async def mock_handle_response(_response):
+            yield mock_response
+
+        with patch(
+            "dashscope.api_entities.http_request.get_shared_aio_session",
+            return_value=mock_session,
+        ):
+            with patch.object(
+                http_request,
+                "_handle_aio_response",
+                side_effect=mock_handle_response,
+            ):
+                _ = await http_request.aio_call()
+
+        assert mock_session.request.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retry_exhausted_raises(self):
+        """连续两次 ClientConnectionError 后向上抛出"""
+        mock_session = AsyncMock()
+        mock_session.request.side_effect = aiohttp.ClientConnectionError(
+            "Server disconnected",
+        )
+
+        http_request = self._build_post_request()
+
+        with patch(
+            "dashscope.api_entities.http_request.get_shared_aio_session",
+            return_value=mock_session,
+        ):
+            with pytest.raises(aiohttp.ClientConnectionError):
+                _ = await http_request.aio_call()
+
+        assert mock_session.request.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_no_retry_on_other_exceptions(self):
+        """非连接类异常不重试"""
+        mock_session = AsyncMock()
+        mock_session.request.side_effect = ValueError("bad request")
+
+        http_request = self._build_post_request()
+
+        with patch(
+            "dashscope.api_entities.http_request.get_shared_aio_session",
+            return_value=mock_session,
+        ):
+            with pytest.raises(ValueError, match="bad request"):
+                _ = await http_request.aio_call()
+
+        assert mock_session.request.call_count == 1

--- a/tests/unit/test_sync_custom_session.py
+++ b/tests/unit/test_sync_custom_session.py
@@ -574,8 +574,8 @@ class TestSyncConnectionRetry:
     def test_retry_exhausted_raises(self, mock_get_session):
         """连续两次 ConnectionError 后向上抛出"""
         mock_session = Mock()
-        mock_session.post.side_effect = (
-            requests.exceptions.ConnectionError("Connection aborted.")
+        mock_session.post.side_effect = requests.exceptions.ConnectionError(
+            "Connection aborted.",
         )
         mock_get_session.return_value = mock_session
 

--- a/tests/unit/test_sync_custom_session.py
+++ b/tests/unit/test_sync_custom_session.py
@@ -514,3 +514,88 @@ class TestSyncBackwardCompatibility:
         mock_get_session.assert_called_once()
         # 验证共享 session 没有被关闭
         mock_session.close.assert_not_called()
+
+
+class TestSyncConnectionRetry:
+    """测试池化连接被远端关闭后的重试行为"""
+
+    def _build_post_request(self):
+        http_request = HttpRequest(
+            url="http://example.com/api",
+            api_key="fake-api-key",
+            http_method=HTTPMethod.POST,
+            stream=False,
+        )
+        http_request.data = ApiRequestData(
+            model="test-model",
+            task_group="test",
+            task="test",
+            function="test",
+            input_data={"test": "data"},
+            form=None,
+            is_binary_input=False,
+            api_protocol=ApiProtocol.HTTPS,
+        )
+        return http_request
+
+    @staticmethod
+    def _ok_response():
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.text = '{"status": "success"}'
+        return mock_response
+
+    @patch("dashscope.api_entities.http_request._get_shared_sync_session")
+    def test_retry_once_on_connection_error(self, mock_get_session):
+        """连接被远端关闭时重试一次并成功"""
+        mock_session = Mock()
+        mock_response = self._ok_response()
+        mock_session.post.side_effect = [
+            requests.exceptions.ConnectionError(
+                "Connection aborted.",
+            ),
+            mock_response,
+        ]
+        mock_get_session.return_value = mock_session
+
+        http_request = self._build_post_request()
+
+        with patch.object(
+            http_request,
+            "_handle_response",
+            return_value=iter([mock_response]),
+        ):
+            _ = http_request.call()
+
+        assert mock_session.post.call_count == 2
+
+    @patch("dashscope.api_entities.http_request._get_shared_sync_session")
+    def test_retry_exhausted_raises(self, mock_get_session):
+        """连续两次 ConnectionError 后向上抛出"""
+        mock_session = Mock()
+        mock_session.post.side_effect = (
+            requests.exceptions.ConnectionError("Connection aborted.")
+        )
+        mock_get_session.return_value = mock_session
+
+        http_request = self._build_post_request()
+
+        with pytest.raises(requests.exceptions.ConnectionError):
+            _ = http_request.call()
+
+        assert mock_session.post.call_count == 2
+
+    @patch("dashscope.api_entities.http_request._get_shared_sync_session")
+    def test_no_retry_on_other_exceptions(self, mock_get_session):
+        """非连接类异常不重试"""
+        mock_session = Mock()
+        mock_session.post.side_effect = ValueError("bad request")
+        mock_get_session.return_value = mock_session
+
+        http_request = self._build_post_request()
+
+        with pytest.raises(ValueError, match="bad request"):
+            _ = http_request.call()
+
+        assert mock_session.post.call_count == 1


### PR DESCRIPTION
## Summary
- 1.26.5 (PR #165) introduced a process-lifetime shared `requests.Session` for connection pooling. urllib3 has no client-side idle timeout, so a keep-alive connection closed by the server/LB stays in the pool and the next request reusing it fails with `RemoteDisconnected: Remote end closed connection without response` (observed in production on 1.26.6; 1.26.2 created a fresh connection per request and was unaffected).
- Add `_send_with_retry` in `dashscope/api_entities/http_request.py`: retry **exactly once** when `requests.exceptions.ConnectionError` is raised before any response bytes arrive — the request was never processed, so resending on a fresh connection is safe and cannot duplicate in-flight requests.
- Applied to the JSON POST and GET paths of `_handle_request`; multipart form uploads are not retried (file bodies may not be re-sendable). Read timeouts, 5xx, and other errors are never retried.
- Bump version to 1.26.7.

## Test plan
- [x] `pytest tests/unit/test_sync_custom_session.py` — 19 passed, including 3 new cases: retry-once succeeds, second ConnectionError propagates (exactly 2 attempts), non-connection errors are not retried
- [x] `pytest tests/unit` — 435 passed, 6 skipped
- [ ] Verify in a long-running production worker that `RemoteDisconnected` errors no longer surface