### PR TITLE
feat(agentstudio): support deployment environment variables

### DIFF
--- a/dashscope/agentstudio/resources/deployments.py
+++ b/dashscope/agentstudio/resources/deployments.py
@@ -45,6 +45,7 @@ class Deployments:
         schedule: Any = None,
         resources: Optional[Sequence[Any]] = None,
         vault_ids: Optional[Sequence[str]] = None,
+        environment_variables: Optional[Mapping[str, str]] = None,
         metadata: Optional[Mapping[str, str]] = None,
     ) -> Deployment:
         body = DeploymentCreateParams(
@@ -56,6 +57,7 @@ class Deployments:
             schedule=schedule,
             resources=resources,
             vault_ids=vault_ids,
+            environment_variables=environment_variables,
             metadata=metadata,
         ).to_dict()
         resp = self._client.transport.request(
@@ -86,6 +88,7 @@ class Deployments:
         initial_events: Optional[Sequence[Mapping[str, Any]]] = None,
         resources: Optional[Sequence[Any]] = None,
         vault_ids: Optional[Sequence[str]] = None,
+        environment_variables: Optional[Mapping[str, str]] = None,
         metadata: Optional[Mapping[str, str]] = None,
     ) -> Deployment:
         body = DeploymentUpdateParams(
@@ -97,6 +100,7 @@ class Deployments:
             initial_events=initial_events,
             resources=resources,
             vault_ids=vault_ids,
+            environment_variables=environment_variables,
             metadata=metadata,
         ).to_dict()
         resp = self._client.transport.request(
@@ -249,6 +253,7 @@ class AsyncDeployments:
         schedule: Any = None,
         resources: Optional[Sequence[Any]] = None,
         vault_ids: Optional[Sequence[str]] = None,
+        environment_variables: Optional[Mapping[str, str]] = None,
         metadata: Optional[Mapping[str, str]] = None,
     ) -> Deployment:
         body = DeploymentCreateParams(
@@ -260,6 +265,7 @@ class AsyncDeployments:
             schedule=schedule,
             resources=resources,
             vault_ids=vault_ids,
+            environment_variables=environment_variables,
             metadata=metadata,
         ).to_dict()
         resp = await self._client.transport.request(
@@ -290,6 +296,7 @@ class AsyncDeployments:
         initial_events: Optional[Sequence[Mapping[str, Any]]] = None,
         resources: Optional[Sequence[Any]] = None,
         vault_ids: Optional[Sequence[str]] = None,
+        environment_variables: Optional[Mapping[str, str]] = None,
         metadata: Optional[Mapping[str, str]] = None,
     ) -> Deployment:
         body = DeploymentUpdateParams(
@@ -301,6 +308,7 @@ class AsyncDeployments:
             initial_events=initial_events,
             resources=resources,
             vault_ids=vault_ids,
+            environment_variables=environment_variables,
             metadata=metadata,
         ).to_dict()
         resp = await self._client.transport.request(

--- a/dashscope/agentstudio/types/models.py
+++ b/dashscope/agentstudio/types/models.py
@@ -847,6 +847,7 @@ class DeploymentPausedReason(BaseModel):
 class Deployment(BaseModel):
     """Managed Agent deployment."""
 
+    environment_variables: Optional[Dict[str, str]]
     metadata: Optional[Dict[str, str]]
 
     _fields = (
@@ -860,6 +861,7 @@ class Deployment(BaseModel):
         "initial_events",
         "resources",
         "vault_ids",
+        "environment_variables",
         "metadata",
         "status",
         "paused_reason",

--- a/dashscope/agentstudio/types/params.py
+++ b/dashscope/agentstudio/types/params.py
@@ -549,6 +549,7 @@ class DeploymentCreateParams(BaseModel):
         "initial_events",
         "resources",
         "vault_ids",
+        "environment_variables",
         "metadata",
     )
 
@@ -563,6 +564,7 @@ class DeploymentCreateParams(BaseModel):
         schedule: Any = None,
         resources: Optional[Sequence[Any]] = None,
         vault_ids: Optional[Sequence[str]] = None,
+        environment_variables: Optional[Mapping[str, str]] = None,
         metadata: Optional[Mapping[str, str]] = None,
     ) -> None:
         BaseModel.__init__(
@@ -579,6 +581,11 @@ class DeploymentCreateParams(BaseModel):
                 else None
             ),
             vault_ids=(list(vault_ids) if vault_ids is not None else None),
+            environment_variables=(
+                dict(environment_variables)
+                if environment_variables is not None
+                else None
+            ),
             metadata=(dict(metadata) if metadata is not None else None),
         )
 
@@ -600,6 +607,7 @@ class DeploymentUpdateParams(BaseModel):
         "initial_events",
         "resources",
         "vault_ids",
+        "environment_variables",
         "metadata",
     )
 
@@ -614,6 +622,7 @@ class DeploymentUpdateParams(BaseModel):
         initial_events: Optional[Sequence[Mapping[str, Any]]] = None,
         resources: Optional[Sequence[Any]] = None,
         vault_ids: Optional[Sequence[str]] = None,
+        environment_variables: Optional[Mapping[str, str]] = None,
         metadata: Optional[Mapping[str, str]] = None,
     ) -> None:
         self._environment_id_given = environment_id is not _NOT_GIVEN
@@ -641,6 +650,11 @@ class DeploymentUpdateParams(BaseModel):
                 else None
             ),
             vault_ids=(list(vault_ids) if vault_ids is not None else None),
+            environment_variables=(
+                dict(environment_variables)
+                if environment_variables is not None
+                else None
+            ),
             metadata=(dict(metadata) if metadata is not None else None),
         )
 

--- a/tests/unit/test_agentstudio_deployments.py
+++ b/tests/unit/test_agentstudio_deployments.py
@@ -50,6 +50,7 @@ def _deployment_payload() -> Dict[str, Any]:
             },
         ],
         "vault_ids": ["vault_01"],
+        "environment_variables": {"API_BASE_URL": "https://example.test"},
         "metadata": {"biz": "summary"},
         "status": "active",
         "paused_reason": {
@@ -162,6 +163,7 @@ def test_create_serializes_contract_and_hydrates_nested_models(client: Client):
             },
         ],
         vault_ids=["vault_01"],
+        environment_variables={"API_BASE_URL": "https://example.test"},
         metadata={"biz": "summary"},
     )
 
@@ -171,6 +173,9 @@ def test_create_serializes_contract_and_hydrates_nested_models(client: Client):
     assert call["json"]["agent"] == {"id": "agent_01", "version": 12}
     assert call["json"]["initial_events"][0]["type"] == "message"
     assert call["json"]["schedule"]["timezone"] == "Asia/Shanghai"
+    assert call["json"]["environment_variables"] == {
+        "API_BASE_URL": "https://example.test",
+    }
     assert call["json"]["metadata"] == {"biz": "summary"}
     assert isinstance(deployment.agent, Agent)
     assert deployment.agent.version == 12
@@ -178,6 +183,9 @@ def test_create_serializes_contract_and_hydrates_nested_models(client: Client):
     assert isinstance(deployment.resources[0], DeploymentResource)
     assert isinstance(deployment.paused_reason, DeploymentPausedReason)
     assert isinstance(deployment.paused_reason.error, DeploymentError)
+    assert deployment.environment_variables == {
+        "API_BASE_URL": "https://example.test",
+    }
     assert deployment.metadata == {"biz": "summary"}
     assert deployment.request_id == "req_01"
 
@@ -187,18 +195,21 @@ def test_update_distinguishes_omitted_and_explicit_null(client: Client):
     omitted_body = client.transport.calls[-1]["json"]
     assert "environment_id" not in omitted_body
     assert "schedule" not in omitted_body
+    assert "environment_variables" not in omitted_body
 
     client.deployments.update(
         "depl_01",
         environment_id=None,
         schedule=None,
         resources=[],
+        environment_variables={},
         metadata={},
     )
     clear_body = client.transport.calls[-1]["json"]
     assert clear_body["environment_id"] is None
     assert clear_body["schedule"] is None
     assert clear_body["resources"] == []
+    assert clear_body["environment_variables"] == {}
     assert clear_body["metadata"] == {}
 
 
@@ -263,6 +274,7 @@ def test_async_resources_use_same_contract():
             name="daily-summary",
             agent={"id": "agent_01"},
             initial_events=[user_message("Summarize")],
+            environment_variables={"API_BASE_URL": "https://example.test"},
             metadata={"biz": "summary"},
         )
         run = await client.deployments.run("depl_01")
@@ -271,6 +283,9 @@ def test_async_resources_use_same_contract():
         assert deployment.id == "depl_01"
         assert client.transport.calls[0]["json"]["metadata"] == {
             "biz": "summary",
+        }
+        assert client.transport.calls[0]["json"]["environment_variables"] == {
+            "API_BASE_URL": "https://example.test"
         }
         assert run.id == "drun_01"
         assert runs.data[0].id == "drun_01"

--- a/tests/unit/test_agentstudio_deployments.py
+++ b/tests/unit/test_agentstudio_deployments.py
@@ -285,7 +285,7 @@ def test_async_resources_use_same_contract():
             "biz": "summary",
         }
         assert client.transport.calls[0]["json"]["environment_variables"] == {
-            "API_BASE_URL": "https://example.test"
+            "API_BASE_URL": "https://example.test",
         }
         assert run.id == "drun_01"
         assert runs.data[0].id == "drun_01"


### PR DESCRIPTION
## Summary

Deployment 的 create / update 支持 `environment_variables`，响应模型回显该字段。用于给部署运行时注入环境变量：deployment run 创建 session 时由服务端透传，最终注入沙箱运行时。

契约与 session 侧一致：
- `Mapping[str, str]`，键值均为字符串
- update 为整体覆盖语义：传空字典清空，不传不修改
- 不需要 `_NOT_GIVEN` 那套区分（与 `metadata` 一致）

同步 `Deployments` 与异步 `AsyncDeployments` 两条路径都已透传。

## Changes

- `types/params.py`：`DeploymentCreateParams` / `DeploymentUpdateParams` 新增字段
- `types/models.py`：`Deployment` 新增字段用于回显
- `resources/deployments.py`：同步与异步的 `create` / `update` 共 4 处签名透出该参数
- `tests/unit/test_agentstudio_deployments.py`：补测试与 fixture

## Test plan

- [x] `pytest tests/unit/test_agentstudio_deployments.py` —— 5 个用例通过
- [x] create 用例断言字段写入请求体，且响应模型能回显
- [x] update 用例断言不传时请求体不含该字段、传空字典时为空对象（清空语义）
- [x] 异步用例断言异步路径同样写入请求体
- [x] `black --line-length=79` 与 `flake8 --extend-ignore=E203` 均通过（版本与 .pre-commit-config.yaml 一致）